### PR TITLE
Enabled matchend command for non-admins and fixed typographic errors

### DIFF
--- a/switch.js
+++ b/switch.js
@@ -217,6 +217,7 @@ export default class Switch extends DiscordBasePlugin {
                     this.addPlayerToMatchendSwitches(pl)
                     break;
                 case "doublesquad":
+                    if (!isAdmin) return;
                     await this.server.updateSquadList();
                     await this.server.updatePlayerList();
                     this.doubleSwitchSquad(+commandSplit[ 1 ], commandSplit[ 2 ])
@@ -229,6 +230,7 @@ export default class Switch extends DiscordBasePlugin {
                     await this.addSquadToMatchendSwitches(+commandSplit[ 1 ], commandSplit[ 2 ])
                     break;
                 case "triggermatchend":
+                    if (!isAdmin) return;
                     this.warn(steamID, 'Switch: Triggering matchend for testing purposes');
                     await this.doSwitchMatchend();
                     this.warn(steamID, 'Switch: Done');

--- a/switch.js
+++ b/switch.js
@@ -202,7 +202,7 @@ export default class Switch extends DiscordBasePlugin {
                     this.warn(steamID, `Switch slots per team:\n 1) ${this.getSwitchSlotsPerTeam(1)}\n 2) ${this.getSwitchSlotsPerTeam(2)}`)
                     break;
                 case "matchend":
-                    if (!isAdmin) return;
+                    pl = isAdmin ? this.getPlayerByUsernameOrSteamID(steamID, commandSplit.splice(1).join(' ')) : pl = this.getPlayerBySteamID(steamID);
                     await this.server.updatePlayerList();
                     // const switchData = {
                     //     from: +info.player.teamID,

--- a/switch.js
+++ b/switch.js
@@ -130,7 +130,7 @@ export default class Switch extends DiscordBasePlugin {
 
 
         this.broadcast = (msg) => { this.server.rcon.broadcast(msg); };
-        this.warn = (steamid, msg) => { this.server.rcon.warn(steamid, msg); };
+        this.warn = (steamid, msg) => { this.server.rcon.warn(steamid, msg); this.verbose(1, `Warned ${steamid}: "${msg}"`) };
     }
 
     async mount() {
@@ -242,7 +242,9 @@ export default class Switch extends DiscordBasePlugin {
                     }, 2000)
                     break;
                 case "help":
-                    let msg = `${this.options.commandPrefix}\n > now {username|steamID}\n > double {username|steamID}\n > matchend {username|steamID}\n > squad {squad_number} {teamID|teamString}\n > doublesquad {squad_number} {teamID|teamString}\n > matchendsquad {squad_number} {teamID|teamString}`;
+                    let msg = `${this.options.commandPrefix}\n\n > now {username|steamID}\n > double {username|steamID}\n > matchend {username|steamID}\n`;
+                    this.warn(steamID, msg);
+                    msg = `${this.options.commandPrefix}\n\n > squad {squad_number} {teamID|teamString}\n\n > doublesquad {squad_number} {teamID|teamString}\n > matchendsquad {squad_number} {teamID|teamString}`;
                     this.warn(steamID, msg);
                     break;
                 default:

--- a/switch.js
+++ b/switch.js
@@ -335,7 +335,8 @@ export default class Switch extends DiscordBasePlugin {
     }
 
     async onPlayerConnected(info) {
-        const { steamID, name: playerName, teamID } = info.player;
+        const steamID = info.steamID;
+        const playerName = info.player?.name;
         this.verbose(1, `Player connected ${playerName}`)
 
         this.playersConnectionTime[ steamID ] = new Date()
@@ -343,7 +344,8 @@ export default class Switch extends DiscordBasePlugin {
     }
 
     async onPlayerDisconnected(info) {
-        const { steamID, name: playerName, teamID } = info.player;
+        const steamID = info.steamID;
+        const teamID = info.player?.teamID;
 
         // this.recentSwitches = this.recentSwitches.filter(p => p.steamID != steamID);
         this.recentDisconnections[ steamID ] = { teamID: teamID, time: new Date() }
@@ -353,7 +355,12 @@ export default class Switch extends DiscordBasePlugin {
     async switchToPreDisconnectionTeam(info) {
         if (!this.options.switchToOldTeamAfterRejoin) return;
 
-        const { steamID, name: playerName, teamID } = info.player;
+        const steamID = info.steamID;
+
+        if (!info.player) return;
+        const playerName = info.player?.name;
+        const teamID = info.player?.teamID;
+
         const preDisconnectionData = this.recentDisconnections[ steamID ];
         if (!preDisconnectionData) return;
 

--- a/switch.js
+++ b/switch.js
@@ -22,7 +22,7 @@ export default class Switch extends DiscordBasePlugin {
             },
             // duringMatchSwitchSlots: {
             //     required: true,
-            //     description: "Number of switch slots, if one is free a player will instanlty get a switch",
+            //     description: "Number of switch slots, if one is free a player will instantly get a switch",
             //     default: 2
             // },
             doubleSwitchCommands: {
@@ -100,13 +100,13 @@ export default class Switch extends DiscordBasePlugin {
         this.getSwitchSlotsPerTeam = this.getSwitchSlotsPerTeam.bind(this);
         this.onRoundEnded = this.onRoundEnded.bind(this);
         this.addPlayerToMatchendSwitches = this.addPlayerToMatchendSwitches.bind(this);
-        this.doSwitcMatchend = this.doSwitcMatchend.bind(this);
+        this.doSwitchMatchend = this.doSwitchMatchend.bind(this);
 
         this.playersConnectionTime = [];
         this.matchEndSwitch = new Array(this.options.endMatchSwitchSlots > 0 ? this.options.endMatchSwitchSlots : 0);
         this.recentSwitches = [];
         this.recentDoubleSwitches = [];
-        this.recentDisconnetions = [];
+        this.recentDisconnections = [];
 
         this.models = {};
 
@@ -230,7 +230,7 @@ export default class Switch extends DiscordBasePlugin {
                     break;
                 case "triggermatchend":
                     this.warn(steamID, 'Switch: Triggering matchend for testing purposes');
-                    await this.doSwitcMatchend();
+                    await this.doSwitchMatchend();
                     this.warn(steamID, 'Switch: Done');
                     break;
                 case "test":
@@ -260,7 +260,7 @@ export default class Switch extends DiscordBasePlugin {
             const cooldownHoursLeft = (+recentSwitch?.datetime - +(new Date())) / (60 * 60 * 1000);
 
             if (this.getSecondsFromJoin(steamID) / 60 > this.options.switchEnabledMinutes && this.getSecondsFromMatchStart() / 60 > this.options.switchEnabledMinutes) {
-                this.warn(steamID, `A switch can be requested only in the first ${this.options.doubleSwitchEnabledMinutes} mintues from match start or connection to the server`);
+                this.warn(steamID, `A switch can be requested only in the first ${this.options.doubleSwitchEnabledMinutes} minutes from match start or connection to the server`);
                 return;
             }
 
@@ -283,7 +283,7 @@ export default class Switch extends DiscordBasePlugin {
         }
     }
 
-    async doSwitcMatchend() {
+    async doSwitchMatchend() {
         const players = await this.models.Endmatch.findAll();
         if (players.length == 0) return;
         players.forEach((pl) => {
@@ -301,7 +301,7 @@ export default class Switch extends DiscordBasePlugin {
     }
 
     async onRoundEnded(dt) {
-        this.doSwitcMatchend();
+        this.doSwitchMatchend();
 
         for (let p of this.server.players)
             p.teamID = p.teamID == 1 ? 2 : 1
@@ -341,7 +341,7 @@ export default class Switch extends DiscordBasePlugin {
         const { steamID, name: playerName, teamID } = info.player;
 
         // this.recentSwitches = this.recentSwitches.filter(p => p.steamID != steamID);
-        this.recentDisconnetions[ steamID ] = { teamID: teamID, time: new Date() }
+        this.recentDisconnections[ steamID ] = { teamID: teamID, time: new Date() }
         this.recentDoubleSwitches = this.recentDoubleSwitches.filter(p => p.steamID != steamID);
     }
 
@@ -349,7 +349,7 @@ export default class Switch extends DiscordBasePlugin {
         if (!this.options.switchToOldTeamAfterRejoin) return;
 
         const { steamID, name: playerName, teamID } = info.player;
-        const preDisconnectionData = this.recentDisconnetions[ steamID ];
+        const preDisconnectionData = this.recentDisconnections[ steamID ];
         if (!preDisconnectionData) return;
 
         const needSwitch = teamID != preDisconnectionData.teamID;
@@ -370,7 +370,7 @@ export default class Switch extends DiscordBasePlugin {
 
         if (!forced) {
             if (this.getSecondsFromJoin(steamID) / 60 > this.options.doubleSwitchEnabledMinutes && this.getSecondsFromMatchStart() / 60 > this.options.doubleSwitchEnabledMinutes) {
-                this.warn(steamID, `A double switch can be requested only in the first ${this.options.doubleSwitchEnabledMinutes} mintues from match start or connection to the server`);
+                this.warn(steamID, `A double switch can be requested only in the first ${this.options.doubleSwitchEnabledMinutes} minutes from match start or connection to the server`);
                 return;
             }
 
@@ -389,7 +389,7 @@ export default class Switch extends DiscordBasePlugin {
         await delay(this.options.doubleSwitchDelaySeconds * 1000)
         await this.server.rcon.execute(`AdminForceTeamChange ${steamID}`);
 
-        if (forced && senderSteamID) this.warn(senderSteamID, `Player has been doble-switched`)
+        if (forced && senderSteamID) this.warn(senderSteamID, `Player has been double-switched`)
     }
 
     switchSquad(number, team) {

--- a/switch.js
+++ b/switch.js
@@ -271,7 +271,7 @@ export default class Switch extends DiscordBasePlugin {
             if (recentSwitch && cooldownHoursPassed < this.options.switchCooldownHours) {
                 const cooldownHoursLeft = this.options.switchCooldownHours - cooldownHoursPassed;
                 const cooldownMinutesLeft = Math.round(cooldownHoursLeft * 60);
-                const cooldownTimeLeft = cooldownHoursLeft >= 1 ? `${cooldownHoursLeft} hours` : `${cooldownMinutesLeft} minutes`;
+                const cooldownTimeLeft = cooldownHoursLeft >= 1 ? `${cooldownHoursLeft} hour(s)` : `${cooldownMinutesLeft} minute(s)`;
                 this.warn(steamID, `You can switch again after ${cooldownTimeLeft}`);
                 return;
             }
@@ -391,7 +391,7 @@ export default class Switch extends DiscordBasePlugin {
             if (recentSwitch && cooldownHoursPassed < this.options.doubleSwitchCooldownHours) {
                 const cooldownHoursLeft = this.options.doubleSwitchCooldownHours - cooldownHoursPassed;
                 const cooldownMinutesLeft = Math.round(cooldownHoursLeft * 60);
-                const cooldownTimeLeft = cooldownHoursLeft >= 1 ? `${cooldownHoursLeft} hours` : `${cooldownMinutesLeft} minutes`;
+                const cooldownTimeLeft = cooldownHoursLeft >= 1 ? `${cooldownHoursLeft} hour(s)` : `${cooldownMinutesLeft} minute(s)`;
                 this.warn(steamID, `You can double switch again after ${cooldownTimeLeft}`);
                 return;    
             }

--- a/switch.js
+++ b/switch.js
@@ -271,7 +271,7 @@ export default class Switch extends DiscordBasePlugin {
             if (recentSwitch && cooldownHoursPassed < this.options.switchCooldownHours) {
                 const cooldownHoursLeft = this.options.switchCooldownHours - cooldownHoursPassed;
                 const cooldownMinutesLeft = Math.round(cooldownHoursLeft * 60);
-                const cooldownTimeLeft = cooldownHoursLeft >= 1 ? `${cooldownHoursLeft} hour(s)` : `${cooldownMinutesLeft} minute(s)`;
+                const cooldownTimeLeft = cooldownHoursLeft >= 1 ? `${cooldownHoursLeft.toFixed(2)} hour(s)` : `${cooldownMinutesLeft} minute(s)`;
                 this.warn(steamID, `You can switch again after ${cooldownTimeLeft}`);
                 return;
             }
@@ -391,7 +391,7 @@ export default class Switch extends DiscordBasePlugin {
             if (recentSwitch && cooldownHoursPassed < this.options.doubleSwitchCooldownHours) {
                 const cooldownHoursLeft = this.options.doubleSwitchCooldownHours - cooldownHoursPassed;
                 const cooldownMinutesLeft = Math.round(cooldownHoursLeft * 60);
-                const cooldownTimeLeft = cooldownHoursLeft >= 1 ? `${cooldownHoursLeft} hour(s)` : `${cooldownMinutesLeft} minute(s)`;
+                const cooldownTimeLeft = cooldownHoursLeft >= 1 ? `${cooldownHoursLeft.toFixed(2)} hour(s)` : `${cooldownMinutesLeft} minute(s)`;
                 this.warn(steamID, `You can double switch again after ${cooldownTimeLeft}`);
                 return;    
             }

--- a/switch.js
+++ b/switch.js
@@ -168,6 +168,7 @@ export default class Switch extends DiscordBasePlugin {
         this.verbose(1, 'Received command', message, commandPrefixInUse)
 
         const commandSplit = message.substring(commandPrefixInUse.length).trim().split(' ');
+        const playerParameter = commandSplit.splice(1).join(' ');
         const subCommand = commandSplit[ 0 ];
 
 
@@ -177,12 +178,12 @@ export default class Switch extends DiscordBasePlugin {
             switch (subCommand) {
                 case 'now':
                     if (!isAdmin) return;
-                    pl = this.getPlayerByUsernameOrSteamID(steamID, commandSplit.splice(1).join(' '))
+                    pl = this.getPlayerByUsernameOrSteamID(steamID, playerParameter)
                     if (pl) this.switchPlayer(pl.steamID)
                     break;
                 case 'double':
                     if (!isAdmin) return;
-                    pl = this.getPlayerByUsernameOrSteamID(steamID, commandSplit.splice(1).join(' '))
+                    pl = this.getPlayerByUsernameOrSteamID(steamID, playerParameter)
                     if (pl) this.doubleSwitchPlayer(pl.steamID, true)
                     break;
                 case 'squad':
@@ -202,7 +203,7 @@ export default class Switch extends DiscordBasePlugin {
                     this.warn(steamID, `Switch slots per team:\n 1) ${this.getSwitchSlotsPerTeam(1)}\n 2) ${this.getSwitchSlotsPerTeam(2)}`)
                     break;
                 case "matchend":
-                    pl = isAdmin ? this.getPlayerByUsernameOrSteamID(steamID, commandSplit.splice(1).join(' ')) : pl = this.getPlayerBySteamID(steamID);
+                    pl = isAdmin && playerParameter.length > 0 ? this.getPlayerByUsernameOrSteamID(steamID, playerParameter) : this.getPlayerBySteamID(steamID);
                     await this.server.updatePlayerList();
                     // const switchData = {
                     //     from: +info.player.teamID,
@@ -212,7 +213,7 @@ export default class Switch extends DiscordBasePlugin {
                     // if (matchEndSwitch.filter(s => s.to == switchData.to)) {
                     //     this.matchEndSwitch[ steamID.toString() ] = 
                     // }
-                    pl = this.getPlayerByUsernameOrSteamID(steamID, commandSplit.splice(1).join(' '))
+                    pl = this.getPlayerByUsernameOrSteamID(steamID, playerParameter)
                     this.warn(steamID, `Player ${pl.name} will be switched at the end of the current match`);
                     this.addPlayerToMatchendSwitches(pl)
                     break;

--- a/switch.js
+++ b/switch.js
@@ -203,8 +203,8 @@ export default class Switch extends DiscordBasePlugin {
                     this.warn(steamID, `Switch slots per team:\n 1) ${this.getSwitchSlotsPerTeam(1)}\n 2) ${this.getSwitchSlotsPerTeam(2)}`)
                     break;
                 case "matchend":
-                    pl = isAdmin && playerParameter.length > 0 ? this.getPlayerByUsernameOrSteamID(steamID, playerParameter) : this.getPlayerBySteamID(steamID);
                     await this.server.updatePlayerList();
+                    pl = isAdmin && playerParameter ? this.getPlayerByUsernameOrSteamID(steamID, playerParameter) : this.getPlayerBySteamID(steamID);
                     // const switchData = {
                     //     from: +info.player.teamID,
                     //     to: [ 1, 2 ].find(i => i != +info.player.teamID)
@@ -213,7 +213,6 @@ export default class Switch extends DiscordBasePlugin {
                     // if (matchEndSwitch.filter(s => s.to == switchData.to)) {
                     //     this.matchEndSwitch[ steamID.toString() ] = 
                     // }
-                    pl = this.getPlayerByUsernameOrSteamID(steamID, playerParameter)
                     this.warn(steamID, `Player ${pl.name} will be switched at the end of the current match`);
                     this.addPlayerToMatchendSwitches(pl)
                     break;


### PR DESCRIPTION
Improved the logic of `matchend` command to allow non-admins to use the command, as well as admins to use the command without the need of the player parameter.